### PR TITLE
add demo, forum and slack to the header

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -7,15 +7,6 @@ import GuideSearchWidget
   from '../../components/GuideSearchWidget/GuideSearchWidget';
 import Nav from './Nav/Nav';
 
-import guidesIcon from '../../static/images/icn-guides.svg';
-import guidesMobileIcon from '../../static/images/icn-guides-mobile.svg';
-import guidesActiveIcon from '../../static/images/icn-guides-active.svg';
-import apiRefIcon from '../../static/images/icn-api-ref.svg';
-import apiRefMobileIcon from '../../static/images/icn-api-ref-mobile.svg';
-import apiRefActiveIcon from '../../static/images/icn-api-ref-active.svg';
-import supportIcon from '../../static/images/icn-support.svg';
-import supportMobileIcon from '../../static/images/icn-support-mobile.svg';
-import supportActiveIcon from '../../static/images/icn-support-active.svg';
 
 import './Header.scss';
 
@@ -25,23 +16,22 @@ const NavigationItemsProps = [
   {
     text: 'Guides',
     href: '/guides/',
-    img: guidesIcon,
-    imageOnMobile: guidesMobileIcon,
-    activeImageOnMobile: guidesActiveIcon,
   },
   {
     text: 'API Referece',
     href: '/api-reference/',
-    img: apiRefIcon,
-    imageOnMobile: apiRefMobileIcon,
-    activeImageOnMobile: apiRefActiveIcon,
   },
   {
-    text: 'Support',
-    href: '/support/',
-    img: supportIcon,
-    imageOnMobile: supportMobileIcon,
-    activeImageOnMobile: supportActiveIcon,
+    text: 'Demo',
+    href: 'https://demo.skygear.io/',
+  },
+  {
+    text: 'Forum',
+    href: 'https://discuss.skygear.io/',
+  },
+  {
+    text: 'Slack',
+    href: 'https://slack.skygear.io/',
   },
 ];
 
@@ -79,16 +69,14 @@ class Header extends Component {
   renderNaviationItem({ text, href, ...otherProps }) {
     const currentPathname = window.location.pathname;
     let isActive = false;
-    let autoHref = href;
     if (currentPathname.indexOf(href) === 0) {
-      autoHref = '#';
       isActive = true;
     }
 
     return (
       <Nav
         key={`nav-item-${text.toLowerCase()}`}
-        href={autoHref}
+        href={href}
         text={text}
         active={isActive}
         {...otherProps}

--- a/components/Header/Header.scss
+++ b/components/Header/Header.scss
@@ -70,34 +70,9 @@
             opacity: 0.8;
           }
 
-          img {
-            display: inline-block;
-            height: 24px;
-            width: auto;
-            margin: 12px 18px;
-            vertical-align: middle;
-
-            @include mobile {
-              display: none;
-            }
-
-            &.mobile {
-              display: none;
-
-              @include mobile {
-                display: inline-block;
-              }
-            }
-
-            &.mobile-active {
-              display: none;
-            }
-          }
-
           span {
             display: inline-block;
             margin: 12px 18px;
-            margin-left: 0;
             font-size: 16px;
             line-height: 24px;
             vertical-align: middle;
@@ -109,18 +84,6 @@
 
           &.active {
             background-color: $header-nav-item-active-color;
-
-            img {
-              @include mobile {
-                display: none;
-              }
-
-              &.mobile-active {
-                @include mobile {
-                  display: inline-block;
-                }
-              }
-            }
 
             span {
               @include mobile {
@@ -168,14 +131,6 @@
 
           &:hover {
             opacity: 1;
-          }
-
-          img {
-            display: inline-block;
-
-            &.mobile {
-              display: none;
-            }
           }
 
           span {

--- a/components/Header/Nav/Nav.js
+++ b/components/Header/Nav/Nav.js
@@ -6,9 +6,6 @@ const Nav = (props) => {
   const {
     active,
     href,
-    img,
-    imageOnMobile,
-    activeImageOnMobile,
     text,
     className,
     ...otherProps
@@ -41,7 +38,7 @@ const Nav = (props) => {
 
   return (
     <a
-      target='_blank'
+      target="_blank"
       className={cxNames}
       href={href}
       {...otherProps}

--- a/components/Header/Nav/Nav.js
+++ b/components/Header/Nav/Nav.js
@@ -15,23 +15,6 @@ const Nav = (props) => {
   } = props;
 
   const content = [
-    <img
-      key="nav-img"
-      src={img}
-      alt={text}
-    />,
-    <img
-      key="nav-img-mobile"
-      className="mobile"
-      src={imageOnMobile || img}
-      alt={text}
-    />,
-    <img
-      key="nav-img-mobile-active"
-      className="mobile-active"
-      src={activeImageOnMobile || imageOnMobile || img}
-      alt={text}
-    />,
     <span key="nav-text">
       {text}
     </span>,
@@ -44,7 +27,7 @@ const Nav = (props) => {
       className.split(' '),
     );
 
-  if (href && href.indexOf('#') !== 0) {
+  if (href && href.indexOf('https') !== 0) {
     return (
       <Link
         className={cxNames}
@@ -58,8 +41,9 @@ const Nav = (props) => {
 
   return (
     <a
+      target='_blank'
       className={cxNames}
-      href="#"
+      href={href}
       {...otherProps}
     >
       {content}
@@ -69,11 +53,8 @@ const Nav = (props) => {
 
 Nav.propTypes = {
   active: PropTypes.bool,
-  activeImageOnMobile: PropTypes.string,
-  imageOnMobile: PropTypes.string,
   className: PropTypes.string,
   href: PropTypes.string,
-  img: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
To improve the discoverability of our demos and support, I have added 'Demo', 'Forum' and 'Slack' to the header. To make things simple, I simply remove all the icons in front of the nav items. 

I have updated part of the codes, but I am not sure if the implementation is okay. The major worry I have is about the removal of "href='#'. I have removed href="#" because I think it is not working. I guess originally we want the page to go to the top when users click on the active nav item. However it is currently blocked by the header. If we are to do it we need make it go back to the top of the component instead of the page. Just my two cents tho, please let me know if you want me to put the href="#" back. 🙇‍♀️🙇‍♀️🙇‍♀️🙇‍♀️